### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0]
 ### Added
 - Interactive run when no `--names` are specified
 - Index can be selected with a short id: `-i node`, `-i python`
@@ -16,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workflow comment is populated from description in index
 
 ### Fixed
-- Handle invalid YAML error in workflow
+- Handle invalid user YAML in workflow
 
 ## [0.6.0-rc.1]
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "private": false,
   "description": "CLI tool to install and update GitHub Actions",
   "main": "lib/index.js",


### PR DESCRIPTION
### Added
- Interactive run when no `--names` are specified
- Index can be selected with a short id: `-i node`, `-i python`
- Index `documentation` field that contains a documentation URL
- Index `workflows.[].secrets` field with a list of secrets used in workflow

### Changed
- `--names existing` replaced with `--names installed`
- Workflow comment is populated from description in index

### Fixed
- Handle invalid user YAML in workflow